### PR TITLE
feat: add libadwaita tag for Celluloid

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 
 ### Video Players
 
-- [Celluloid (ex GNOME MPV)](https://github.com/celluloid-player/celluloid) #c
+- [Celluloid (ex GNOME MPV)](https://github.com/celluloid-player/celluloid) #c #libadwaita
 - [Clapper](https://github.com/Rafostar/clapper) #gjs #c
 - [Movie Monad](https://github.com/lettier/movie-monad) #haskell
 - [GNOME Videos (Totem)](https://wiki.gnome.org/Apps/Videos) #c #gnome


### PR DESCRIPTION

Celluloid uses libadwaita since v0.24.
https://github.com/celluloid-player/celluloid/releases/tag/v0.24